### PR TITLE
Fix for "TypeError: Cannot assign to read only property 'ids' of obje…

### DIFF
--- a/dist/local-conditional-card.js
+++ b/dist/local-conditional-card.js
@@ -48,7 +48,7 @@ class LocalConditionalCard extends LitElement {
                 let new_ids = serviceData.ids.filter(ido => getId(ido)[0] !== this._config.id);
                 if (new_ids.length === 0)
                     return Promise.resolve();
-                serviceData.ids = new_ids;
+                serviceData = { ids: new_ids };
                 return callService(domain, service, serviceData);
             }
             return callService(domain, service, serviceData);


### PR DESCRIPTION
Fixed local_conditional_card.set `TypeError` as described [here](https://github.com/PiotrMachowski/Home-Assistant-Lovelace-Local-Conditional-card/issues/6)